### PR TITLE
Add README and fix index.html typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Enable Zoom App Real Time Media Streams: Media-accessing apps
+
+This repository hosts a web-based Google Codelab that walks developers through enabling Real Time Media Streams (RTMS) for Zoom Apps. The tutorial covers app prerequisites, updating Marketplace metadata with the Manifest API, enabling RTMS at install time, and configuring account settings to auto-open an RTMS-enabled app.
+
+## Prerequisites
+- Code editor and terminal
+- Zoom Developer Account with RTMS enabled
+
+## Usage
+Open `index.html` in a web browser. Each step explains how RTMS works and includes a sample Manifest JSON object showing required scopes, event subscriptions, and app options.
+
+## Resources
+- [Real-Time Media Streams (RTMS) docs](https://developers.zoom.us/docs/rtms/)
+- [Embedded Zoom Web Meeting SDK](https://developers.zoom.us/docs/meeting-sdk/web/)
+
+## License
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/index.html
+++ b/index.html
@@ -29,13 +29,13 @@
                   feedback-link="https://devforum.zoom.us/c/zoom-apps">
     
       <google-codelab-step label="Before you begin" duration="0">
-        <p>This codelab is a series focused on enable Zoom Real Time Media.</p>
+          <p>This codelab is a series focused on enabling Zoom Real Time Media.</p>
 
 
       </google-codelab-step>
     
-      <google-codelab-step label="What you&#39;ll learn" duration="0">
-        <p>Enable Zoom App Real Time Media Streams with Zoom Markerplace app.</p>
+        <google-codelab-step label="What you&#39;ll learn" duration="0">
+          <p>Enable Zoom App Real Time Media Streams with Zoom Marketplace app.</p>
 <h2 is-upgraded>What you&#39;ll need</h2>
 <ul>
 <li>Code editor and terminal</li>
@@ -73,7 +73,7 @@
 </li>
 </ul>
 <h2 is-upgraded><strong>Zoom Manifest API Request Body:</strong></h2>
-<p><strong>Zoom Manifest API JSON Ojbect</strong></p>
+ <p><strong>Zoom Manifest API JSON Object</strong></p>
 <pre><code language="language-javascript" class="language-javascript">{
     &#34;manifest&#34;: {
         &#34;display_information&#34;: {
@@ -284,9 +284,9 @@
     
       <google-codelab-step label="Conclusion" duration="0">
         <p>Congratulations! You now have a Zoom App Task Manager application built with Next.js that integrates with Supabase for authentication and storage, with Zoom Chat, Chatbot, and Real time media streams enabled.</p>
-<h2 is-upgraded>What Next</h2>
+  <h2 is-upgraded>What&#39;s Next</h2>
 <ul>
-<li><a href="https://developers.zoom.us/docs/meeting-sdk/web/" target="_blank">Embeded Zoom Web Meeting SDK</a></li>
+  <li><a href="https://developers.zoom.us/docs/meeting-sdk/web/" target="_blank">Embedded Zoom Web Meeting SDK</a></li>
 </ul>
 
 


### PR DESCRIPTION
## Summary
- Document project overview, usage, resources, and license in new README
- Correct Marketplace, JSON Object, and Embedded typos in codelab index.html
- Improve phrasing for intro and conclusion sections

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f5b22fa88328b14e026dede95f7f